### PR TITLE
Fixes for timer behaviour

### DIFF
--- a/app/src/main/java/com/sherryyuan/emomtimer/timer/TimerCountdownFragment.kt
+++ b/app/src/main/java/com/sherryyuan/emomtimer/timer/TimerCountdownFragment.kt
@@ -114,9 +114,8 @@ class TimerCountdownFragment : Fragment() {
 
     private fun updateButtons(timerViewState: TimerViewState) {
         @DrawableRes val buttonDrawable: Int = when (timerViewState) {
-            TimerViewState.NOT_STARTED -> R.drawable.icon_play_arrow
+            TimerViewState.NOT_STARTED, TimerViewState.PAUSED -> R.drawable.icon_play_arrow
             TimerViewState.RUNNING -> R.drawable.icon_pause
-            TimerViewState.PAUSED -> R.drawable.icon_play_arrow
             else -> R.drawable.icon_play_arrow
         }
         binding.timerControllerButton.isVisible = timerViewState != TimerViewState.STARTING
@@ -145,6 +144,7 @@ class TimerCountdownFragment : Fragment() {
                 this,
                 object : OnBackPressedCallback(true) {
                     override fun handleOnBackPressed() {
+                        viewModel.pause()
                         if (viewModel.timerViewState.value == TimerViewState.NOT_STARTED) {
                             isEnabled = false
                             activity.onBackPressed()
@@ -157,6 +157,7 @@ class TimerCountdownFragment : Fragment() {
                                 }
                                 .setNegativeButton(R.string.cancel) { dialog, _ ->
                                     dialog.cancel()
+                                    viewModel.resume()
                                 }
                                 .create()
                                 .show()

--- a/app/src/main/java/com/sherryyuan/emomtimer/timer/viewmodel/TimerViewModel.kt
+++ b/app/src/main/java/com/sherryyuan/emomtimer/timer/viewmodel/TimerViewModel.kt
@@ -34,13 +34,13 @@ abstract class TimerViewModel : ViewModel(), KoinComponent {
     protected val audioPlayer: AudioPlayer = get()
     protected val resourcesProvider: ResourcesProvider by inject()
 
+    private val countdownTimerToStart: CountDownTimer = createCountdownTimerToStart()
     private var timer: CountDownTimer? = null
-    private var countdownTimerToStart: CountDownTimer = createCountdownTimerToStart()
     private var hasSaidNextExercise = false
 
     override fun onCleared() {
-        timer?.cancel()
         countdownTimerToStart.cancel()
+        timer?.cancel()
         timer = null
         audioPlayer.shutdown()
     }

--- a/app/src/main/java/com/sherryyuan/emomtimer/timer/viewmodel/TimerViewModel.kt
+++ b/app/src/main/java/com/sherryyuan/emomtimer/timer/viewmodel/TimerViewModel.kt
@@ -35,9 +35,12 @@ abstract class TimerViewModel : ViewModel(), KoinComponent {
     protected val resourcesProvider: ResourcesProvider by inject()
 
     private var timer: CountDownTimer? = null
+    private var countdownTimerToStart: CountDownTimer = createCountdownTimerToStart()
+    private var hasSaidNextExercise = false
 
     override fun onCleared() {
         timer?.cancel()
+        countdownTimerToStart.cancel()
         timer = null
         audioPlayer.shutdown()
     }
@@ -49,6 +52,7 @@ abstract class TimerViewModel : ViewModel(), KoinComponent {
     @CallSuper
     open fun startNextExercise(startTimer: Boolean = true) {
         audioPlayer.playBeep()
+        hasSaidNextExercise = false
         setupTimer(_timerViewData.value?.getRemainingMillisInSet() ?: 0L)
         if (startTimer) {
             viewModelScope.launch {
@@ -78,7 +82,7 @@ abstract class TimerViewModel : ViewModel(), KoinComponent {
 
     fun start() {
         _timerViewState.value = TimerViewState.STARTING
-        playCountdownToStart()
+        countdownTimerToStart.start()
     }
 
     /**
@@ -88,6 +92,7 @@ abstract class TimerViewModel : ViewModel(), KoinComponent {
     fun pause() {
         _timerViewState.value = TimerViewState.PAUSED
         timer?.cancel()
+        countdownTimerToStart.cancel()
     }
 
     fun resume() {
@@ -109,9 +114,8 @@ abstract class TimerViewModel : ViewModel(), KoinComponent {
     private fun setupTimer(millisRemaining: Long) {
         // Cancel any existing timer.
         timer?.cancel()
+        countdownTimerToStart.cancel()
         timer = object : CountDownTimer(millisRemaining, MILLIS_PER_SECOND.toLong()) {
-
-            var hasSaidNextExercise = false
 
             override fun onTick(millisUntilFinished: Long) {
                 // Say the next exercise the first time onTick() is called with < 8 seconds left.
@@ -133,41 +137,37 @@ abstract class TimerViewModel : ViewModel(), KoinComponent {
     /**
      * Count down for 3 seconds before starting the workout.
      */
-    private fun playCountdownToStart() {
-        val countdownTimerToStart =
-            object : CountDownTimer(EIGHT_SECONDS, MILLIS_PER_SECOND.toLong()) {
+    private fun createCountdownTimerToStart(): CountDownTimer =
+        object : CountDownTimer(EIGHT_SECONDS, MILLIS_PER_SECOND.toLong()) {
+            var hasSaidFirstExercise = false
+            var lastCountedSecond = 4
 
-                var hasSaidNextExercise = false
-                var lastCountedSecond = 4
-
-                override fun onTick(millisUntilFinished: Long) {
-                    // Say the next exercise the first time onTick() is called with < 8 seconds left.
-                    if (!hasSaidNextExercise && millisUntilFinished < EIGHT_SECONDS) {
-                        sayFirstExercise()
-                        hasSaidNextExercise = true
-                    }
-                    when {
-                        (lastCountedSecond > 3 && millisUntilFinished < THREE_SECONDS) -> {
-                            audioPlayer.speak("3")
-                            lastCountedSecond--
-                        }
-                        (lastCountedSecond > 2 && millisUntilFinished < TWO_SECONDS) -> {
-                            audioPlayer.speak("2")
-                            lastCountedSecond--
-                        }
-                        (lastCountedSecond > 1 && millisUntilFinished < ONE_SECOND) -> {
-                            audioPlayer.speak("1")
-                            lastCountedSecond--
-                        }
-                    }
+            override fun onTick(millisUntilFinished: Long) {
+                // Say the next exercise the first time onTick() is called with < 8 seconds left.
+                if (!hasSaidFirstExercise && millisUntilFinished < EIGHT_SECONDS) {
+                    sayFirstExercise()
+                    hasSaidFirstExercise = true
                 }
-
-                override fun onFinish() {
-                    audioPlayer.playBeep()
-                    resume()
-                    this.cancel()
+                when {
+                    (lastCountedSecond > 3 && millisUntilFinished < THREE_SECONDS) -> {
+                        audioPlayer.speak("3")
+                        lastCountedSecond--
+                    }
+                    (lastCountedSecond > 2 && millisUntilFinished < TWO_SECONDS) -> {
+                        audioPlayer.speak("2")
+                        lastCountedSecond--
+                    }
+                    (lastCountedSecond > 1 && millisUntilFinished < ONE_SECOND) -> {
+                        audioPlayer.speak("1")
+                        lastCountedSecond--
+                    }
                 }
             }
-        countdownTimerToStart.start()
-    }
+
+            override fun onFinish() {
+                audioPlayer.playBeep()
+                resume()
+                this.cancel()
+            }
+        }
 }


### PR DESCRIPTION
* When user hits "back" and sees the confirmation dialog, timer is automatically paused for them
* Make sure `countdownTimerToStart` also gets cancelled if user leaves the timer screen
* Make `hasSaidNextExercise` a global variable so that if the timer gets recreated, it'll know if a previous timer already said the next exercise.